### PR TITLE
example - oauth2 userinfo with opaque token

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/provider/oauth/ExternalOAuthAuthenticationManager.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/provider/oauth/ExternalOAuthAuthenticationManager.java
@@ -52,6 +52,7 @@ import org.cloudfoundry.identity.uaa.oauth.jwt.JwtHelper;
 import org.cloudfoundry.identity.uaa.oauth.jwt.SignatureVerifier;
 import org.cloudfoundry.identity.uaa.oauth.jwt.UaaMacSigner;
 import org.cloudfoundry.identity.uaa.oauth.token.ClaimConstants;
+import org.cloudfoundry.identity.uaa.oauth.token.TokenConstants;
 import org.cloudfoundry.identity.uaa.provider.AbstractExternalOAuthIdentityProviderDefinition;
 import org.cloudfoundry.identity.uaa.provider.AbstractExternalOAuthIdentityProviderDefinition.OAuthGroupMappingMode;
 import org.cloudfoundry.identity.uaa.provider.ExternalIdentityProviderDefinition;
@@ -789,6 +790,7 @@ public class ExternalOAuthAuthenticationManager extends ExternalLoginAuthenticat
         headers.add("Accept", "application/json");
 
         URI requestUri;
+        body.add(TokenConstants.REQUEST_TOKEN_FORMAT, TokenConstants.TokenFormat.OPAQUE.getStringValue());
         HttpEntity requestEntity = new HttpEntity<>(body, headers);
         try {
             requestUri = config.getTokenUrl().toURI();


### PR DESCRIPTION
```
{
  "type": "oauth2.0",
  "config": {
    "emailDomain": null,
    "additionalConfiguration": null,
    "providerDescription": null,
    "externalGroupsWhitelist": [
      "*"
    ],
    "attributeMappings": {
      "given_name": "user_name",
      "external_groups": "scope",
      "user.attribute.the_client_id": "cid"
    },
    "addShadowUserOnLogin": true,
    "storeCustomAttributes": true,
    "authUrl": "http://localhost:8080/uaa/oauth/authorize",
    "tokenUrl": "http://localhost:8080/uaa/oauth/token",
    "tokenKeyUrl": "http://localhost:8080/uaa/token_key",
    "tokenKey": null,
    "userInfoUrl": "http://localhost:8080/uaa/userinfo",
    "logoutUrl": "http://localhost:8080/uaa/logout.do",
    "linkText": "My Oauth2.0 Provider",
    "showLinkText": true,
    "clientAuthInBody": false,
    "skipSslValidation": true,
    "relyingPartyId": "identity",
    "scopes": [
      "openid",
      "cloud_controller.read"
    ],
    "issuer": "http://localhost:8080/uaa/oauth/token",
    "responseType": "code",
    "userPropagationParameter": null,
    "pkce": true,
    "performRpInitiatedLogout": true,
    "authMethod": "client_secret_basic",
    "cacheJwks": true,
    "discoveryUrl": null,
    "passwordGrantEnabled": false,
    "setForwardHeader": false,
    "tokenExchangeEnabled": null
  },
  "id": "a09e5b82-5a42-4809-b314-d6e102fdcf70",
  "originKey": "puppy",
  "name": "my oidc provider",
  "version": 0,
  "created": 1758135352194,
  "last_modified": 1758135352194,
  "active": true,
  "identityZoneId": "oidcloginit",
  "aliasId": null,
  "aliasZid": null
}
```